### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/support.yaml
+++ b/.github/workflows/support.yaml
@@ -6,6 +6,10 @@ on:
   issues:
     types: [labeled, unlabeled, reopened]
 
+permissions:
+  contents: read
+  issues: write
+
 jobs:
   support:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/khumbal/dnsmadeeasy-webhook/security/code-scanning/5](https://github.com/khumbal/dnsmadeeasy-webhook/security/code-scanning/5)

Add an explicit `permissions` block to `.github/workflows/support.yaml` so the workflow documents and enforces least privilege.  
Best approach here: set permissions at the **workflow root** (applies to all jobs unless overridden), since there is a single job. For this issue-handling automation, required scopes are:
- `issues: write` (to comment/close issues)
- `contents: read` (safe baseline read access)

Edit region: near the top-level keys, after `on:` block and before `jobs:`.  
No imports, methods, or dependencies are needed (YAML-only change).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
