### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/invalid-template.yaml
+++ b/.github/workflows/invalid-template.yaml
@@ -6,6 +6,10 @@ on:
   issues:
     types: [labeled, unlabeled, reopened]
 
+permissions:
+  contents: read
+  issues: write
+
 jobs:
   support:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/khumbal/dnsmadeeasy-webhook/security/code-scanning/4](https://github.com/khumbal/dnsmadeeasy-webhook/security/code-scanning/4)

Add an explicit `permissions` block to the workflow so `GITHUB_TOKEN` is least-privileged and documented.  
For this workflow, the action operates on issues (comment/close/lock), so the minimal practical scope is:

- `contents: read` (safe baseline for most actions)
- `issues: write` (required for commenting/closing/locking issues)

Best single fix without changing functionality: add a root-level `permissions` block under `on:` and before `jobs:` so it applies to all jobs in this workflow (currently just `support`).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
