### PR TITLE
fix(dns): correct zone matching; re-enable CI triggers, expand dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,15 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+  - package-ecosystem: "gomod"
+    directory: "/src" # go.mod/go.sum live under src/
+    schedule:
+      interval: "weekly"
+    groups:
+      go-modules:
+        patterns:
+          - "*"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,17 +2,17 @@ name: CI
 
 on:
   workflow_dispatch:
-  # push:
-  #   tags:
-  #   - "v*.*.*"
-  #   branches:
-  #   - "release/*"
+  push:
+    tags:
+    - "v*.*.*"
+    branches:
+    - main
   pull_request:
     types:
     - opened
     - reopened
-  # schedule:
-  # - cron: "0 0 * * 6"
+  schedule:
+  - cron: "0 0 * * 6"
 
 env:
   REGISTRY_IMAGE: ghcr.io/${{ github.repository }}

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,7 @@
 bin
 _out
 apiserver.local.config/**
+
+# Stray go-build binary produced by `go build .` in src/ (module-named)
+/src/dnsmadeeasy-webhook
+/src/webhook

--- a/src/main.go
+++ b/src/main.go
@@ -245,7 +245,7 @@ func (c *DNSMadeEasyProviderSolver) getDnsClient(ch *webhookapi.ChallengeRequest
 		if !ok {
 			return nil, fmt.Errorf("no apiKeyRef for %q in secret '%s/%s'", ref.Name, ref.Key, ch.ResourceNamespace)
 		}
-		apiKey = fmt.Sprintf("%s", apiKeyRef)
+		apiKey = string(apiKeyRef)
 	}
 
 	//API Secret
@@ -263,7 +263,7 @@ func (c *DNSMadeEasyProviderSolver) getDnsClient(ch *webhookapi.ChallengeRequest
 		if !ok {
 			return nil, fmt.Errorf("no accessKeySecret for %q in secret '%s/%s'", ref.Name, ref.Key, ch.ResourceNamespace)
 		}
-		apiSecret = fmt.Sprintf("%s", apiSecretRef)
+		apiSecret = string(apiSecretRef)
 	}
 
 	APIUrl := GoDNSMadeEasy.LIVEAPI
@@ -288,19 +288,25 @@ func (c *DNSMadeEasyProviderSolver) getDnsClient(ch *webhookapi.ChallengeRequest
 func getDomainID(client *GoDNSMadeEasy.GoDMEConfig, zone string) (int, error) {
 	domains, err := client.Domains()
 	if err != nil {
-		return -1, fmt.Errorf("dnspod API call failed: %v", err)
+		return -1, fmt.Errorf("DNSMadeEasy API call failed: %v", err)
 	}
 
 	authZone, err := util.FindZoneByFqdn(context.Background(), zone, util.RecursiveNameservers)
 	if err != nil {
 		return -1, err
 	}
+	authZone = util.UnFqdn(authZone)
 
+	// Pick the most specific managed domain that is authZone itself or a parent
+	// of it. Matching on a label boundary ("." + name) avoids false positives
+	// such as "notexample.com" matching a managed "example.com" zone, and the
+	// longest-match keeps nested zones (e.g. "sub.example.com") correct.
 	var hostedDomain GoDNSMadeEasy.Domain
 	for _, domain := range domains {
-		if strings.HasSuffix(util.UnFqdn(authZone), domain.Name) {
-			hostedDomain = domain
-			break
+		if authZone == domain.Name || strings.HasSuffix(authZone, "."+domain.Name) {
+			if len(domain.Name) > len(hostedDomain.Name) {
+				hostedDomain = domain
+			}
 		}
 	}
 


### PR DESCRIPTION
## Summary

Follow-up improvements after the angelnu→khumbal merge (#11/#12).

### 🔴 Bug fix — wrong DNS zone selection (`src/main.go`)
`getDomainID` matched a managed DNSMadeEasy zone with a loose suffix check that ignored label boundaries and stopped at the **first** match. For accounts with overlapping or nested domain names this could resolve to the **wrong zone** and present the ACME challenge TXT record in the wrong domain:

- `example.com` + `notexample.com` → `"notexample.com"` matched `example.com`
- nested `example.com` + delegated `sub.example.com` → parent picked over the real apex

Now matches on a label boundary (`authZone == name` or `."+name`) and keeps the **longest (most specific)** zone.

### 🟡 Cleanups (`src/main.go`)
- `string([]byte)` instead of `fmt.Sprintf("%s", …)` (2 spots)
- Fix copy-pasted `"dnspod"` provider name in an error message → `DNSMadeEasy`

### 🟢 Infra
- **CI** (`ci.yaml`): re-enable `push` (tags `v*.*.*` + `main`) and weekly `schedule` triggers so images publish automatically again
- **Dependabot**: add `gomod` (`/src`, grouped) and `github-actions` ecosystems (previously only `docker`) — keeps Go deps & actions current and avoids the stale-dependency drift that made the last merge painful
- **.gitignore**: ignore the module-named `go build` artifact under `src/`

## Verification
- ✅ `go build ./...` · `go vet ./...` — clean
- ✅ `go fmt` — no diff
- ✅ YAML parses (ci.yaml + dependabot.yml)
- ✅ envtest harness boots; integration test only needs real DNSMadeEasy creds (`TEST_ZONE_NAME`) to run fully

🤖 Generated with [Claude Code](https://claude.com/claude-code)