### PR TITLE
fix(deps): bump controller-runtime to v0.24.1 for k8s v0.36.1 compat

### DIFF
--- a/src/go.mod
+++ b/src/go.mod
@@ -38,7 +38,6 @@ require (
 	github.com/go-openapi/swag/jsonname v0.25.4 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/protobuf v1.5.4 // indirect
-	github.com/google/btree v1.1.3 // indirect
 	github.com/google/cel-go v0.26.0 // indirect
 	github.com/google/gnostic-models v0.7.1 // indirect
 	github.com/google/pprof v0.0.0-20260115054156-294ebfa9ad83 // indirect
@@ -110,7 +109,7 @@ require (
 	k8s.io/streaming v0.36.1 // indirect
 	k8s.io/utils v0.0.0-20260210185600-b8788abfbbc2 // indirect
 	sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.34.0 // indirect
-	sigs.k8s.io/controller-runtime v0.23.1 // indirect
+	sigs.k8s.io/controller-runtime v0.24.1 // indirect
 	sigs.k8s.io/gateway-api v1.5.0 // indirect
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect

--- a/src/go.sum
+++ b/src/go.sum
@@ -310,8 +310,8 @@ k8s.io/utils v0.0.0-20260210185600-b8788abfbbc2 h1:AZYQSJemyQB5eRxqcPky+/7EdBj0x
 k8s.io/utils v0.0.0-20260210185600-b8788abfbbc2/go.mod h1:xDxuJ0whA3d0I4mf/C4ppKHxXynQ+fxnkmQH0vTHnuk=
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.34.0 h1:hSfpvjjTQXQY2Fol2CS0QHMNs/WI1MOSGzCm1KhM5ec=
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.34.0/go.mod h1:Ve9uj1L+deCXFrPOk1LpFXqTg7LCFzFso6PA48q/XZw=
-sigs.k8s.io/controller-runtime v0.23.1 h1:TjJSM80Nf43Mg21+RCy3J70aj/W6KyvDtOlpKf+PupE=
-sigs.k8s.io/controller-runtime v0.23.1/go.mod h1:B6COOxKptp+YaUT5q4l6LqUJTRpizbgf9KSRNdQGns0=
+sigs.k8s.io/controller-runtime v0.24.1 h1:miPEwrmirImAvgME1L9qebGHrOnGJoVmVdtOU9fRfo4=
+sigs.k8s.io/controller-runtime v0.24.1/go.mod h1:vFkfY5fGt5xAC/sKb8IBFKgWPNKG9OUG29dR8Y2wImw=
 sigs.k8s.io/gateway-api v1.5.0 h1:duoo14Ky/fJXpjpmyMISE2RTBGnfCg8zICfTYLTnBJA=
 sigs.k8s.io/gateway-api v1.5.0/go.mod h1:GvCETiaMAlLym5CovLxGjS0NysqFk3+Yuq3/rh6QL2o=
 sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 h1:IpInykpT6ceI+QxKBbEflcR5EXP7sU1kvOlxwZh5txg=


### PR DESCRIPTION
## Problem
After enabling the `gomod` dependabot ecosystem, a grouped update raised the `k8s.io/*` stack to **v0.36.1**, but `sigs.k8s.io/controller-runtime` stayed at **v0.23.1** (transitively pinned by cert-manager v1.20.2). v0.23.1's cache does not implement client-go v0.36.1's `ResourceEventHandlerRegistration` (missing `HasSyncedChecker`), so the Docker build failed to compile:

```
controller-runtime@v0.23.1/pkg/cache/multi_namespace_cache.go:363:9:
  handlerRegistration does not implement ResourceEventHandlerRegistration (missing method HasSyncedChecker)
```

This broke CI on `main` once the `push` trigger was re-enabled.

## Fix
Bump `controller-runtime` **v0.23.1 → v0.24.1** (targets client-go v0.36), keeping **k8s at v0.36.1**. cert-manager v1.20.2 compiles cleanly against it. Pinning controller-runtime explicitly also keeps future grouped dependabot updates moving it in lockstep with `k8s.io/*`.

## Verification
- ✅ `go build ./...` · `go vet ./...` · `go mod tidy` — clean
- ✅ envtest harness boots (integration test only needs real `TEST_ZONE_NAME` creds to run fully)
- Diff: `controller-runtime v0.23.1 → v0.24.1` in go.mod + go.sum

> Note: the separate GitHub Actions repo policy that caused the earlier *startup failure* (third-party actions blocked) was fixed independently by switching `allowed_actions` to `selected` (github-owned + verified + docker/sigstore/dessant).

🤖 Generated with [Claude Code](https://claude.com/claude-code)