### PR TITLE
fix(deploy): repair broken image publish (Dockerfile apk→apt-get, ghcr login, manual trigger)

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -14,6 +14,8 @@ on:
     tags: [ 'v*.*.*' ]
   pull_request:
    branches: [ "main" ]
+  # Allow the workflow to be triggered manually, e.g. to re-publish a tag.
+  workflow_dispatch:
 
 env:
   # Use docker.io for Docker Hub if empty
@@ -60,7 +62,7 @@ jobs:
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
-          password: ${{ secrets.GHCR_TOKEN }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       # Extract metadata (tags, labels) for Docker
       # https://github.com/docker/metadata-action

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ WORKDIR /workspace
 ENV GO111MODULE=on
 ENV TEST_ASSET_PATH=/_out/kubebuilder/bin
 
-RUN apk update && apk add --no-cache git bash curl g++
+RUN apt-get update && apt-get install -y --no-install-recommends git bash curl g++ && rm -rf /var/lib/apt/lists/*
 
 ARG TEST_ZONE_NAME
 COPY Makefile Makefile


### PR DESCRIPTION
**Description of the change**

The image publish (deploy) pipeline has been fully broken. Investigating why `v1.19.1` never published and the last `v1.19.0` build failed surfaced **two independent bugs**:

1. **Dockerfile build fails for every build** — the build stage runs `apk update && apk add ... g++`, but the base image is `golang:1.26` (Debian bookworm), which has no `apk`:
   ```
   #11 [build 3/10] RUN apk update && apk add --no-cache git bash curl g++
   /bin/sh: 1: apk: not found   (exit code 127)
   ```
   The Dockerfile was written for a `golang:*-alpine` base, but automated digest-bump commits moved the base to the Debian `golang:1.26` image without restoring the package manager. Switched back to `apt-get` (matching the pre-alpine Dockerfile).

2. **Registry login fails on real deploys** — the Docker workflow authenticated to `ghcr.io` with a custom `GHCR_TOKEN` secret (in the `Deploy` environment, last updated ~2 years ago). The `v1.19.0` tag build failed at login with `denied: denied` — an expired/insufficient token. Switched the login to the built-in `GITHUB_TOKEN`; the job already declares `permissions: packages: write`, so it can push and sign this repo's own package without a manually-maintained secret.

Also added a `workflow_dispatch` trigger to `docker-publish.yml` so a deploy can be re-run manually (e.g. to re-publish a tag whose build failed) without cutting a new tag.

**Benefits**

- Image builds actually succeed, so tagged releases publish to `ghcr.io` again.
- Publishing no longer depends on a stale, manually-renewed `GHCR_TOKEN`.
- A missed/failed release build can be re-run on demand from the Actions tab.

**Possible drawbacks**

- Publishing relies on the repository `GITHUB_TOKEN` with `packages: write`; the package's access settings must allow this repository to push (default for repo-owned packages).
- `ci.yaml` has the same `apk` base image but still references `GHCR_TOKEN` via the `Deploy` environment for its own login — this PR does not change `ci.yaml`. Its build stage benefits from the same Dockerfile fix. (Note: `ci.yaml`'s login step already uses `GITHUB_TOKEN`.)

**Applicable issues**

- fixes #

**Additional information**

Verification is via the PR's own CI: on `pull_request` the build runs with `push=false`, so a green `build` check confirms the Dockerfile fix without publishing anything. The `GITHUB_TOKEN`/`workflow_dispatch` changes only take effect on non-PR (tag / manual) runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QZEcV57hEd12TWKP4Uz5Td