### PR TITLE
fix(deps): drop stale controller-runtime v0.20.2 replace so the image builds

### DIFF
--- a/src/go.mod
+++ b/src/go.mod
@@ -19,7 +19,6 @@ replace (
 	k8s.io/apiserver => k8s.io/apiserver v0.36.2
 	k8s.io/client-go => k8s.io/client-go v0.36.2
 	k8s.io/component-base => k8s.io/component-base v0.36.2
-	sigs.k8s.io/controller-runtime => sigs.k8s.io/controller-runtime v0.20.2
 
 	// Crucial: Forces the structured-merge-diff type converter back to v4 signatures
 	sigs.k8s.io/structured-merge-diff/v4 => sigs.k8s.io/structured-merge-diff/v4 v4.4.1
@@ -60,7 +59,6 @@ require (
 	github.com/go-openapi/swag/yamlutils v0.26.0 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/protobuf v1.5.4 // indirect
-	github.com/google/btree v1.1.3 // indirect
 	github.com/google/cel-go v0.26.0 // indirect
 	github.com/google/gnostic-models v0.7.1 // indirect
 	github.com/google/pprof v0.0.0-20260115054156-294ebfa9ad83 // indirect

--- a/src/go.sum
+++ b/src/go.sum
@@ -1,5 +1,7 @@
 cel.dev/expr v0.25.1 h1:1KrZg61W6TWSxuNZ37Xy49ps13NUovb66QLprthtwi4=
 cel.dev/expr v0.25.1/go.mod h1:hrXvqGP6G6gyx8UAHSHJ5RGk//1Oj5nXQ2NI02Nrsg4=
+github.com/Masterminds/semver/v3 v3.4.0 h1:Zog+i5UMtVoCU8oKka5P7i9q9HgrJeGzI9SA1Xbatp0=
+github.com/Masterminds/semver/v3 v3.4.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
 github.com/NYTimes/gziphandler v1.1.1 h1:ZUDjpQae29j0ryrS0u/B8HZfJBtBQHjqw2rQ2cqUQ3I=
 github.com/NYTimes/gziphandler v1.1.1/go.mod h1:n/CVRwUEOgIxrgPvAQhUUr9oeUtvrhMomdKFjzJNB0c=
 github.com/antlr4-go/antlr/v4 v4.13.1 h1:SqQKkuVZ+zWkMMNkjy5FZe5mr5WURWnlpmOuzYWrPrQ=
@@ -137,10 +139,10 @@ github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee h1:W5t00kpgFd
 github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
-github.com/onsi/ginkgo/v2 v2.22.0 h1:Yed107/8DjTr0lKCNt7Dn8yQ6ybuDRQoMGrNFKzMfHg=
-github.com/onsi/ginkgo/v2 v2.22.0/go.mod h1:7Du3c42kxCUegi0IImZ1wUQzMBVecgIHjR1C+NkhLQo=
-github.com/onsi/gomega v1.36.1 h1:bJDPBO7ibjxcbHMgSCoo4Yj18UWbKDlLwX1x9sybDcw=
-github.com/onsi/gomega v1.36.1/go.mod h1:PvZbdDc8J6XJEpDK4HCuRBm8a6Fzp9/DmhC9C7yFlog=
+github.com/onsi/ginkgo/v2 v2.27.4 h1:fcEcQW/A++6aZAZQNUmNjvA9PSOzefMJBerHJ4t8v8Y=
+github.com/onsi/ginkgo/v2 v2.27.4/go.mod h1:ArE1D/XhNXBXCBkKOLkbsb2c81dQHCRcF5zwn/ykDRo=
+github.com/onsi/gomega v1.39.0 h1:y2ROC3hKFmQZJNFeGAMeHZKkjBL65mIZcvrLQBF9k6Q=
+github.com/onsi/gomega v1.39.0/go.mod h1:ZCU1pkQcXDO5Sl9/VVEGlDyp+zm0m1cmeG5TOzLgdh4=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
@@ -328,8 +330,8 @@ k8s.io/utils v0.0.0-20260626114624-be93311217bd h1:Ea7fgQ5we8Y9T0OX5o0dAHzQOBRI0
 k8s.io/utils v0.0.0-20260626114624-be93311217bd/go.mod h1:xDxuJ0whA3d0I4mf/C4ppKHxXynQ+fxnkmQH0vTHnuk=
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.34.0 h1:hSfpvjjTQXQY2Fol2CS0QHMNs/WI1MOSGzCm1KhM5ec=
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.34.0/go.mod h1:Ve9uj1L+deCXFrPOk1LpFXqTg7LCFzFso6PA48q/XZw=
-sigs.k8s.io/controller-runtime v0.20.2 h1:/439OZVxoEc02psi1h4QO3bHzTgu49bb347Xp4gW1pc=
-sigs.k8s.io/controller-runtime v0.20.2/go.mod h1:xg2XB0K5ShQzAgsoujxuKN4LNXR2LfwwHsPj7Iaw+XY=
+sigs.k8s.io/controller-runtime v0.24.1 h1:miPEwrmirImAvgME1L9qebGHrOnGJoVmVdtOU9fRfo4=
+sigs.k8s.io/controller-runtime v0.24.1/go.mod h1:vFkfY5fGt5xAC/sKb8IBFKgWPNKG9OUG29dR8Y2wImw=
 sigs.k8s.io/gateway-api v1.6.0 h1:735YBRj5NXFrOGX0GoSjwzUIzbz8kiEOfADsqHFmHgE=
 sigs.k8s.io/gateway-api v1.6.0/go.mod h1:FVfx3t389ybeXOqvDghLbdvJdSCfI/PReqCUI3lu3mY=
 sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 h1:IpInykpT6ceI+QxKBbEflcR5EXP7sU1kvOlxwZh5txg=


### PR DESCRIPTION
**Description of the change**

After the Docker/CI pipeline was repaired in #33, the image build got past the package-install step and then failed at the Go compile:

```
sigs.k8s.io/controller-runtime@v0.20.2/pkg/cache/multi_namespace_cache.go:361:9:
  cannot use handles (variable of struct type handlerRegistration) as
  "k8s.io/client-go/tools/cache".ResourceEventHandlerRegistration value in return statement:
  handlerRegistration does not implement ...ResourceEventHandlerRegistration
  (missing method HasSyncedChecker)
```

`go.mod` requires `sigs.k8s.io/controller-runtime v0.24.1` (and so does `cert-manager v1.21.0`), but a leftover `replace` directive pinned it down to `v0.20.2`. That old version is incompatible with the `k8s.io/client-go v0.36.2` cache interface (which gained `HasSyncedChecker`), so compilation fails.

This removes the single stale line from the `replace` block:

```
-	sigs.k8s.io/controller-runtime => sigs.k8s.io/controller-runtime v0.20.2
```

so the module resolves controller-runtime to the required `v0.24.1`. The other `replace` pins (k8s.io/* → v0.36.2, structured-merge-diff/v4 → v4.4.1) are left untouched.

**Benefits**

- `go build` and `go vet ./...` pass again; the container image can be built and published.
- Completes the deploy repair started in #33 — the pipeline now works end to end.

**Possible drawbacks**

- Bumps the effective controller-runtime from v0.20.2 to v0.24.1. This is the version already demanded by the module graph and by cert-manager v1.21.0, so it aligns dependencies rather than diverging them.

**Applicable issues**

- fixes #

**Additional information**

Verified locally with Go 1.26.4: `go mod tidy`, `CGO_ENABLED=0 go build`, and `go vet ./...` all succeed. Full end-to-end verification runs in this PR's CI build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QZEcV57hEd12TWKP4Uz5Td

---
_Generated by [Claude Code](https://claude.ai/code/session_01QZEcV57hEd12TWKP4Uz5Td)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency alignment only—no application code changes; effective controller-runtime moves to the version already required by cert-manager and the module graph.
> 
> **Overview**
> Removes a leftover **`replace`** in `go.mod` that forced `sigs.k8s.io/controller-runtime` to **v0.20.2** while the module graph (including cert-manager v1.21.0) expects **v0.24.1** with **k8s.io/client-go v0.36.2**. That mismatch broke compilation because v0.20.2’s cache handlers no longer satisfy the client-go `ResourceEventHandlerRegistration` interface (`HasSyncedChecker`).
> 
> With the pin gone, the build resolves **controller-runtime v0.24.1**; `go.sum` is updated accordingly (including refreshed onsi test deps). Other k8s.io and structured-merge-diff **replace** directives are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7d8bedd7e481fb6d27fd1fdea43c8d98e22a3a20. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->